### PR TITLE
Reduce cure chance of Plague

### DIFF
--- a/code/datums/diseases/plague.dm
+++ b/code/datums/diseases/plague.dm
@@ -12,7 +12,7 @@ Should be near done now.
 	cure = "Spaceacillin"
 	cure_id = "spaceacillin"
 	curable = 1 //Can't be cured without an actual cure administered.
-	cure_chance = 50 //Pretty high chance of curing the disease once you get the cure.
+	cure_chance = 30 //Pretty high chance of curing the disease once you get the cure.
 	agent = "nurgle's blessings"
 	affected_species = list("Human")
 	permeability_mod = 0.75


### PR DESCRIPTION
The 50% cure chance is too harsh, it's easy to cure the Plague even without Viro, people who think you NEED viro to cure the Plague don't know how to actually cure it.