### PR TITLE
Give Eldar Spies blank PDAs and only Agent ID

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -414,13 +414,20 @@ Inquisitor
 	idtype = /obj/item/weapon/card/id/assistant
 
 /datum/job/eldarspy/equip_items(var/mob/living/carbon/human/H)
-	H.verbs += /mob/living/carbon/human/proc/renderaid									 //This is how we get the verb!
+	H.verbs += /mob/living/carbon/human/proc/renderaid //This is how we get the verb!
+	if(!H.unEquip(H.wear_id))
+		qdel(H.wear_id)
+	if(!H.unEquip(H.belt))
+		qdel(H.belt)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/cape(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)  //Looks like an assistant
 	H.equip_to_slot_or_del(new /obj/item/weapon/paper/espy(H), slot_in_backpack)  //With a cloaking device
 	H.equip_to_slot_or_del(new /obj/item/device/soulstone(H), slot_in_backpack)	//and a soulstone. Perfectly normal!
-	H.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate(H), slot_in_backpack)
+	H.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate(H), slot_wear_id)
+	H.equip_to_slot_or_del(new /obj/item/device/pda(H), slot_belt)
+
+	H << "\blue To forge your ID, pull out the card and click on it, you can then insert it into your PDA to update its info." // Tells people how to use the Agent Card
 
 datum/job/assistant/get_access()
 	if(config.jobs_have_maint_access & ASSISTANTS_HAVE_MAINT_ACCESS) //Config has assistant maint access set


### PR DESCRIPTION
This is how they should've been in the first place, honestly.