### PR TITLE
Thousand Sons Magic Changes

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -80,13 +80,13 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			return 0
 
 		if(clothes_req) //clothes check
-			if(!istype(H.wear_suit,  /obj/item/clothing/suit/wizrobe) && !istype(H.wear_suit, /obj/item/clothing/suit/space/rig/wizard))
+			if(!istype(H.wear_suit,  /obj/item/clothing/suit/wizrobe) && !istype(H.wear_suit, /obj/item/clothing/suit/space/rig/wizard) && !istype(H.wear_suit, /obj/item/clothing/suit/armor/thousandarmor))
 				H << "<span class='notice'>I don't feel strong enough without my robe.</span>"
 				return 0
-			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal))
+			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal)&& !istype(H.shoes, /obj/item/clothing/shoes/magboots/ksons))
 				H << "<span class='notice'>I don't feel strong enough without my sandals.</span>"
 				return 0
-			if(!istype(H.head, /obj/item/clothing/head/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/rig/wizard))
+			if(!istype(H.head, /obj/item/clothing/head/wizard) && !istype(H.head, /obj/item/clothing/head/helmet/space/rig/wizard)&& !istype(H.head, /obj/item/clothing/head/helmet/ksonshelmet))
 				H << "<span class='notice'>I don't feel strong enough without my hat.</span>"
 				return 0
 	else

--- a/code/modules/mob/living/carbon/human/whitelisted/thousandsons.dm
+++ b/code/modules/mob/living/carbon/human/whitelisted/thousandsons.dm
@@ -25,12 +25,11 @@ Thousand Sons
 	equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ksonshelmet, slot_head)
 	equip_to_slot_or_del(new /obj/item/weapon/chainsword/ksons_chainsword, slot_belt)
 	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/boltermag/inf, slot_r_store)
-	equip_to_slot_or_del(new /obj/item/weapon/spellbook/oneuse, slot_l_store)
 	equip_to_slot_or_del(new /obj/item/weapon/tank/oxygen/ksons, slot_back)
 	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/bolter/chaos/ksons, slot_s_store)
 	equip_to_slot_or_del(new /obj/item/weapon/shield/riot/ksons, slot_l_hand)
 	verbs += /mob/living/carbon/human/whitelisted/proc/ksonspell
-	
+
 /mob/living/carbon/human/whitelisted/ksons
 	name = "Unknown"
 	real_name = "Unknown"
@@ -54,7 +53,6 @@ Thousand Sons
 	equip_to_slot_or_del(new /obj/item/clothing/head/helmet/ksonshelmet, slot_head)
 	equip_to_slot_or_del(new /obj/item/weapon/chainsword/ksons_chainsword, slot_belt)
 	equip_to_slot_or_del(new /obj/item/ammo_box/magazine/boltermag/inf, slot_r_store)
-	equip_to_slot_or_del(new /obj/item/weapon/spellbook/oneuse, slot_l_store)
 	equip_to_slot_or_del(new /obj/item/weapon/tank/oxygen/ksons, slot_back)
 	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/bolter/chaos/ksons, slot_s_store)
 	equip_to_slot_or_del(new /obj/item/weapon/shield/riot/ksons, slot_l_hand)
@@ -68,6 +66,8 @@ Thousand Sons
 	real_name = "[rndname] the Enlightened"
 	regenerate_icons()
 	rename_self("[name]")
+
+
 
 /mob/living/carbon/human/whitelisted/ksons/Life()
 	..()
@@ -96,8 +96,37 @@ Spell verb
 	set name = "Recieve the gifts of Tzeentch"
 	set desc = "This will give you spells"
 	//set src in usr
-	mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/knock(null)
-	mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/floor(null)
-	mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall(null)
-	mind.spell_list += new /obj/effect/proc_holder/spell/dumbfire/fireball(null)
+
+
+	var/offensivespellchoice = input("Select an offensive spell.","Offensive Spell") as null|anything in list("Fireball", "Blind", "Magic Missile")
+	switch(offensivespellchoice)
+		if("Fireball")
+			mind.spell_list += new /obj/effect/proc_holder/spell/dumbfire/fireball(null)
+
+		if ("Blind")
+			mind.spell_list += new /obj/effect/proc_holder/spell/targeted/trigger/blind
+
+		if ("Magic Missile")
+			mind.spell_list += new /obj/effect/proc_holder/spell/targeted/projectile/magic_missile
+
+
+
+
+	var/utilityspellchoice = input("Select an additional utility spell.","Utility Spell") as null|anything in list("Knock", "Conjure Cult Floor", "Forcewall", "Blink")
+	switch(utilityspellchoice)
+		if("Knock")
+			mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/knock(null)
+
+		if ("Conjure Cult Floor")
+			mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/floor(null)
+
+		if ("Forcewall")
+			mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall(null)
+
+
+		if ("Blink")
+			mind.spell_list += new /obj/effect/proc_holder/spell/targeted/turf_teleport/blink
+
+
+
 	verbs -= /mob/living/carbon/human/whitelisted/proc/ksonspell


### PR DESCRIPTION
>Thousand Sons armor, helmet, and boots now count as wizard attire and spells requiring them can be used freely now

> Upon choosing the Gifts from Tzeentch option, you are now given an option to select 1 offensive spell from a list of a few options, then 1 utility spell from another list

Current offensive spells:
- Fireball
- Magic Missile
- Blind

Current utility spells:
- Conjure Magic Floor 
- Knock
- Forcewall
- Blink

>Removes magic missile book from spawning gear


This is likely going to require some testing to determine if the spells available and the limit of 1 per type works in terms of balance, if not I can revisit this again to tweak things