### PR TITLE
Inquisitor RTD & Acolyte Changes

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -393,10 +393,6 @@ Inquisitorial Acolyte
 				H.equip_to_slot_or_del (new /obj/item/weapon/card/id/inquisitor/ordomalleus(H), slot_wear_id)
 				H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
 
-
-	spawn(10)
-		H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
-
 //--Eldar Spy--
 
 /datum/job/eldarspy

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -335,43 +335,28 @@ Inquisitorial Acolyte
 /datum/job/lawyer
 	title = "Inquisitorial Acolyte"
 	flag = LAWYER
-	department_head = list("Ordo Hereticus")
+	department_head = list("Inquisition")
 	department_flag = CIVILIAN
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 2
-	supervisors = "Ordo Hereticus"
+	supervisors = "Inquisition"
 	selection_color = "#dddddd"
 	var/global/lawyers = 0 //Counts lawyer amount
 	default_backpack = /obj/item/weapon/storage/backpack/satchel
 	default_satchel = /obj/item/weapon/storage/backpack/satchel
 	default_pda = /obj/item/device/pda/lawyer
 	default_headset = /obj/item/device/radio/headset/headset_sec
-	default_id = /obj/item/weapon/card/id/inquisitor
-
-	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom, access_cent_inquisitor, access_cent_general, access_cent_hereticus)
-	minimal_access = list(access_security, access_sec_doors, access_court,
-			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
-			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom, access_cent_inquisitor, access_cent_general, access_cent_hereticus)
+	default_id = null
+	idtype = null
 
 /datum/job/lawyer/equip_items(var/mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/renderaid									 //This is how we get the verb!
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/acolyte(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/armor/acolytecoat(H), slot_wear_suit)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/acolyteboots(H), slot_shoes)
-	H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/laspistol2(H), slot_s_store)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/lawyer(H), slot_in_backpack)
-	H.equip_to_slot_or_del(new /obj/item/weapon/powersword/pknife(H), slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/belt/acolyte(H), slot_belt)
-	H.equip_to_slot_or_del(new /obj/item/device/hdetector(H), slot_in_backpack)
 	H.equip_to_slot_or_del(new /obj/item/clothing/gloves/acolytegloves(H), slot_gloves)
 	H.faction = "Inquisitor"
 
@@ -381,21 +366,36 @@ Inquisitorial Acolyte
 		E.implanted = 1
 
 	spawn(10)
-		H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
+		var/weaponchoice = input(H, "What Ordo does your Inquisitor belong too?","Ordo Selection") as null|anything in list("Ordo Hereticus", "Ordo Xenos", "Ordo Malleus")
+		switch(weaponchoice)
+			if("Ordo Hereticus")
+				H.equip_to_slot_or_del(new /obj/item/weapon/powersword/(H), slot_r_hand)
+				H.equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/laspistol2(H), slot_s_store)
+				H.equip_to_slot_or_del (new /obj/item/device/hdetector(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/weapon/card/id/inquisitor(H), slot_wear_id)
+				H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
+
+			if("Ordo Xenos")
+				H.equip_to_slot_or_del(new /obj/item/weapon/powersword/pknife(H), slot_r_hand)
+				H.equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/pistol/heavy/ox(H), slot_s_store)
+				H.equip_to_slot_or_del (new /obj/item/device/xdetector(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m12mm(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m12mm(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/weapon/card/id/inquisitor/ordoxenos(H), slot_wear_id)
+				H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
+
+			if("Ordo Malleus")
+				H.equip_to_slot_or_del(new /obj/item/weapon/twohanded/chainswordig/inq(H), slot_r_hand)
+				H.equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/bpistol(H), slot_s_store)
+				H.equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/clothing/tie/medal/gold/sealofpurity(H), slot_in_backpack)
+				H.equip_to_slot_or_del (new /obj/item/weapon/card/id/inquisitor/ordomalleus(H), slot_wear_id)
+				H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
+
 
 	spawn(10)
-		var/weaponchoice = input(H, "Select a weapon.","Weapon Selection") as null|anything in list("Power Sword", "Mercy Chainsword", "Hell Pistol", "Stubber Pistol", "Inferno Pistol")
-		switch(weaponchoice)
-			if("Power Sword")
-				H.equip_to_slot_or_del(new /obj/item/weapon/powersword/(H), slot_r_hand)
-			if("Mercy Chainsword")
-				H.equip_to_slot_or_del(new /obj/item/weapon/twohanded/chainswordig/inq(H), slot_r_hand)
-			if("Hell Pistol")
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/hellpistol(H), slot_r_hand)
-			if("Inferno Pistol")
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/inferno(H), slot_r_hand)
-			if("Stubber Pistol")
-				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/pistol(H), slot_r_hand)
+		H.wear_id.name = "[H.real_name]'s Inquisitorial Seal"
 
 //--Eldar Spy--
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -140,9 +140,25 @@ update_label("John Doe", "Clowny")
 
 /obj/item/weapon/card/id/inquisitor
 	name = "Inquisitorial Seal"
-	desc = "An inquisitorial seal. Commands the power of the Ordo Hereticus via proxy."
+	desc = "An inquisitorial seal. Commands the pure and righteous power of the Ordo Hereticus via proxy. This one is covered in dried blood and is slightly charred from laser fire. Intimidating."
 	icon_state = "inquisitor"
 	item_state = "silver_id"
+	assignment = "Inquisitorial Acolyte - Ordo Hereticus"
+	access = list(access_security, access_sec_doors, access_brig, access_court, access_forensics_lockers,
+			            access_medical, access_engine, access_change_ids, access_ai_upload, access_eva, access_heads,
+			            access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
+			            access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
+			            access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
+			            access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_mineral_storeroom, access_cent_inquisitor, access_cent_general, access_cent_hereticus)
+
+
+/obj/item/weapon/card/id/inquisitor/ordoxenos
+	desc = "An inquisitorial seal. Commands the obsessive and neurotic power of the Ordo Xenos via proxy. This one is covered in pieces of odd looking fur, and smells like an Ork. Disgusting."
+	assignment = "Inquisitorial Acolyte - Ordo Xenos"
+
+/obj/item/weapon/card/id/inquisitor/ordomalleus
+	desc = "An inquisitorial seal. Commands the grave and dreadful power of the Ordo Malleus via proxy. This one is covered in sigils, prayers, and blessings. Very holy."
+	assignment = "Inquisitorial Acolyte - Ordo Malleus"
 
 /obj/item/weapon/card/id/inquisitor/New()
 	..()
@@ -233,6 +249,13 @@ update_label("John Doe", "Clowny")
 		..()
 		icon_state = pick("inquisitor", "inquisitor", "inquisitor2", "inquisitor3")
 		name = "Inquisitorial Seal"
+
+/obj/item/weapon/card/id/ordohereticus/ordoxenos
+	assignment = "Ordo Xenos"
+	desc = "An Inquisitorial seal that grants virtually unlimited authority to a full Inquisitor of the Imperium. This one is covered in a suspicious goo like substance and smells like Eldar."
+/obj/item/weapon/card/id/ordohereticus/ordomalleus
+	assignment = "Ordo Malleus"
+	desc = "An Inquisitorial seal that grants virtually unlimited authority to a full Inquisitor of the Imperium. This one is covered in daemon-wards and purity seals."
 
 
 /obj/item/weapon/card/id/ultramarine

--- a/code/game/objects/items/weapons/complex_weapons.dm
+++ b/code/game/objects/items/weapons/complex_weapons.dm
@@ -459,6 +459,10 @@ Eldar PSword
 	piercingpower = 40
 	attack_speedmod = 2
 
+/obj/item/weapon/powersword/mace/om
+	name = "Power Maul"
+	desc = "A brutal looking maul covered in holy rites and blessings. An Inquisitorial Seal is present on the hilt."
+
 /obj/item/weapon/powersword/burning
 	name = "Burning Blade"
 	desc = "A Loi Pattern Burning Blade. Initially a malfunctioning power sword, the overheating of the blade has been put to use in combat. Good at burning heretics."

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -614,7 +614,7 @@ Update: What have we created? something awful -wel ard
 
 		if("ORDOHERETICUS")
 			message_admins("[usr.key] executed RTD faction: OrdoHereticus Inquisitor.", 0)
-			usr << "\blue You are an Ordo Hereticus Inquisitor. The Acolytes on ArchAngel IV have reported all kinds of heresy. It's time to shut this little project down."
+			usr << "\blue You are an Inquisitor attached to a conclave stationed aboard a Black Ship operated by the Ordo Hereticus. The Acolytes on ArchAngel IV have reported all kinds of heresy. It's time to shut this little project down."
 			usr.loc = get_turf(locate("landmark*OHstart"))
 			var/mob/living/carbon/human/OHinq/new_character = new(usr.loc)
 			new_character.key = usr.key

--- a/code/modules/mob/living/carbon/human/whitelisted/ordohereticus.dm
+++ b/code/modules/mob/living/carbon/human/whitelisted/ordohereticus.dm
@@ -287,9 +287,7 @@ Ordo Hereticus
 				equip_to_slot_or_del(W, slot_wear_id)
 
 			if ("Ordo Xenos - Psyker")
-				equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/gyropistol, slot_s_store)
-				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m75, slot_in_backpack)
-				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m75, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/weapon/gun/energy/plasma/pistol, slot_s_store)
 				equip_to_slot_or_del (new /obj/item/device/refractor, slot_in_backpack)
 				equip_to_slot_or_del (new /obj/item/device/xdetector, slot_in_backpack)
 				maxPsyk += 500

--- a/code/modules/mob/living/carbon/human/whitelisted/ordohereticus.dm
+++ b/code/modules/mob/living/carbon/human/whitelisted/ordohereticus.dm
@@ -223,32 +223,104 @@ Ordo Hereticus
 	equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/inq, slot_back)
 	equip_to_slot_or_del(new /obj/item/clothing/under/inq, slot_w_uniform)
 	equip_to_slot_or_del(new /obj/item/clothing/glasses/night, slot_glasses)
-	equip_to_slot_or_del(new /obj/item/clothing/suit/armor/inq, slot_wear_suit)
+	equip_to_slot_or_del(new /obj/item/clothing/suit/armor/inq/random, slot_wear_suit)
 	equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots, slot_shoes)
 	equip_to_slot_or_del(new /obj/item/clothing/head/inqhat, slot_head)
-	equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/laspistol2, slot_s_store)
 	equip_to_slot_or_del(new /obj/item/device/pda/lawyer, slot_in_backpack)
-	equip_to_slot_or_del(new /obj/item/weapon/powersword/pknife, slot_belt)
-	equip_to_slot_or_del(new /obj/item/device/hdetector, slot_in_backpack)
 	equip_to_slot_or_del(new /obj/item/clothing/gloves/combat/inquisitor, slot_gloves)
 	var/obj/item/device/radio/headset/R = new /obj/item/device/radio/headset/headset_cent
 	R.set_frequency(1441)
 	equip_to_slot_or_del(R, slot_ears)
-	var/obj/item/weapon/card/id/ordohereticus/W = new
-	W.access = get_all_accesses()
-	W.access += get_centcom_access("Inquisitorial Acolyte")
-	W.registered_name = real_name
-	W.update_label()
-	equip_to_slot_or_del(W, slot_wear_id)
 	sleep(20)
 	regenerate_icons()
 	rename_self("[name]")
 	verbs += /mob/living/carbon/human/proc/renderaid
+	spawn(20)
+		var/weaponchoice = input("Ordo.","Select an Ordo") as null|anything in list("Ordo Hereticus","Ordo Xenos","Ordo Malleus", "Ordo Hereticus - Psyker", "Ordo Xenos - Psyker", "Ordo Malleus - Psyker")
+		switch(weaponchoice)
+			if ("Ordo Hereticus")
+				equip_to_slot_or_del (new /obj/item/weapon/powersword/burning, slot_r_hand)
+				equip_to_slot_or_del (new /obj/item/weapon/gun/energy/inferno, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/device/hdetector, slot_in_backpack)
+				var/obj/item/weapon/card/id/ordohereticus/W = new
+				W.access = get_all_accesses()
+				W.access += get_centcom_access("Inquisitorial Acolyte")
+				W.registered_name = real_name
+				W.update_label()
+				equip_to_slot_or_del(W, slot_wear_id)
+
+			if ("Ordo Xenos")
+				equip_to_slot_or_del (new /obj/item/weapon/gun/energy/plasma/pistol, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/device/refractor, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/device/xdetector, slot_in_backpack)
+				var/obj/item/weapon/card/id/ordohereticus/ordoxenos/X = new
+				X.access = get_all_accesses()
+				X.access += get_centcom_access("Inquisitorial Acolyte")
+				X.registered_name = real_name
+				X.update_label()
+				equip_to_slot_or_del(X, slot_wear_id)
+
+			if ("Ordo Malleus")
+				equip_to_slot_or_del (new /obj/item/weapon/powersword/mace/om, slot_r_hand)
+				equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/bolter, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag, slot_in_backpack)
+				var/obj/item/weapon/card/id/ordohereticus/ordomalleus/M = new
+				M.access = get_all_accesses()
+				M.access += get_centcom_access("Inquisitorial Acolyte")
+				M.registered_name = real_name
+				M.update_label()
+				equip_to_slot_or_del(M, slot_wear_id)
+
+			if ("Ordo Hereticus - Psyker")
+				equip_to_slot_or_del (new /obj/item/weapon/powersword/burning, slot_r_hand)
+				equip_to_slot_or_del (new /obj/item/weapon/gun/energy/inferno, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/device/hdetector, slot_in_backpack)
+				maxPsyk += 500
+				verbs += /mob/living/carbon/human/proc/psykmode
+				verbs += /mob/living/carbon/human/proc/quickeningg
+				var/obj/item/weapon/card/id/ordohereticus/W = new
+				W.access = get_all_accesses()
+				W.access += get_centcom_access("Inquisitorial Acolyte")
+				W.registered_name = real_name
+				W.update_label()
+				equip_to_slot_or_del(W, slot_wear_id)
+
+			if ("Ordo Xenos - Psyker")
+				equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/gyropistol, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m75, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/m75, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/device/refractor, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/device/xdetector, slot_in_backpack)
+				maxPsyk += 500
+				verbs += /mob/living/carbon/human/proc/psykmode
+				verbs += /mob/living/carbon/human/proc/telepathh
+				var/obj/item/weapon/card/id/ordohereticus/ordoxenos/X = new
+				X.access = get_all_accesses()
+				X.access += get_centcom_access("Inquisitorial Acolyte")
+				X.registered_name = real_name
+				X.update_label()
+				equip_to_slot_or_del(X, slot_wear_id)
+
+			if ("Ordo Malleus - Psyker")
+				equip_to_slot_or_del (new /obj/item/weapon/powersword/mace/om, slot_r_hand)
+				equip_to_slot_or_del (new /obj/item/weapon/gun/projectile/automatic/bolter, slot_s_store)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag, slot_in_backpack)
+				equip_to_slot_or_del (new /obj/item/ammo_box/magazine/bpistolmag, slot_in_backpack)
+				maxPsyk += 500
+				verbs += /mob/living/carbon/human/proc/psykmode
+				var/obj/item/weapon/card/id/ordohereticus/ordomalleus/M = new
+				M.access = get_all_accesses()
+				M.access += get_centcom_access("Inquisitorial Acolyte")
+				M.registered_name = real_name
+				M.update_label()
+				equip_to_slot_or_del(M, slot_wear_id)
+
 /*
 Shuttle verb
 */
 /mob/living/carbon/human/proc/ohshuttle()
-	set category = "Ordo Hereticus"
+	set category = "Inquisitor"
 	set name = "Move ship"
 	set desc = "Like an obediant dog... your ship comes on command."
 	//set src in usr

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -241,3 +241,7 @@ Hell Pistol
 	silenced = null
 	origin_tech = "combat=3;materials=3"
 	mag_type = /obj/item/ammo_box/magazine/m12mm
+
+/obj/item/weapon/gun/projectile/automatic/pistol/heavy/ox
+	name = "Scipio Pattern Stubber pistol"
+	desc = "A beautifally manufactuered Scipio Pattern stubber pistol with an Inquisitorial Sigil emblazoned boldy into the side, this belongs to a very important person."


### PR DESCRIPTION
- Acolyte Loadouts have been revamped, you now choose what Ordo your patron Inquisitor belongs too and your equipment is given based on that.
- OHInq RTD Inquisitors now have access to loadouts, same topic as above, you choose an Ordo and you get your starting equipment based on that.