### PR TITLE
Fix rg jumpacks

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -284,6 +284,7 @@ Security Officer
 		switch(weaponchoice)
 			if("Standard Guardsman")
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/lasgun(H), slot_r_hand)
+				H.equip_to_slot_or_del(new /obj/item/weapon/complexknife/combatknife(H), slot_in_backpack)
 			if("Field Chiurgeon")
 				if(!H.unEquip(H.gloves))
 					qdel(H.gloves)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -284,7 +284,6 @@ Security Officer
 		switch(weaponchoice)
 			if("Standard Guardsman")
 				H.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/lasgun(H), slot_r_hand)
-				H.equip_to_slot_or_del(new /obj/item/weapon/complexknife/combatknife(H), slot_in_backpack)
 			if("Field Chiurgeon")
 				if(!H.unEquip(H.gloves))
 					qdel(H.gloves)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -432,6 +432,20 @@ Lets turn marine powersources into backpacks - wel
 	max_w_class = 3
 	max_combined_w_class = 16
 
+/obj/item/weapon/storage/rgbackpack/verb/activatejetpack()
+    set name = "Activate Jetpack"
+    set category = "Raven Guard"
+    set src in usr
+    if(!usr.canmove || usr.stat || usr.restrained())
+        return
+    activate()
+    playsound(loc, 'sound/effects/bin_close.ogg', 75, 0)
+
+/obj/item/weapon/storage/rgbackpack/proc/activate()
+	usr.equip_to_slot(new /obj/item/weapon/tank/oxygen/jump/rg, slot_back)
+	usr.drop_item()
+	qdel(src)
+
 /obj/item/weapon/storage/pmbackpack
 	name = "Plague Marine Power Pack"
 	desc = "Powers the heavy armor of the Plague Marines"


### PR DESCRIPTION
Someone forgot to copy-paste the jump pack activation code to the new powerpacks, which broke a big part of RG gameplay, this fixes that.