### PR TITLE
Removes Genetic damage from #116

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -349,14 +349,13 @@ obj/item/projectile/kinetic/New()
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "plasma"
 	trace_residue = null
-	damage = 30
+	damage = 45
 	damage_type = BURN
 	woundtype = /datum/wound/melt
 	on_hit(var/atom/target, var/blocked = 0)
 		if(isliving(target))
 			var/mob/living/carbon/M = target
 			M.adjustBrainLoss(15)
-			M.adjustCloneLoss(20)
 			M.hallucination += 20
 
 /obj/item/projectile/beam/destructor/lesser
@@ -364,12 +363,11 @@ obj/item/projectile/kinetic/New()
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "plasmablue"
 	trace_residue = null
-	damage = 20
+	damage = 30
 	damage_type = BURN
 	woundtype = /datum/wound/burn
 	on_hit(var/atom/target, var/blocked = 0)
 		if(isliving(target))
 			var/mob/living/carbon/M = target
 			M.adjustBrainLoss(10)
-			M.adjustCloneLoss(15)
 			M.hallucination += 10


### PR DESCRIPTION
Removes Genetic damage from eldar's spells, it's a pain in the ass and it's use should be kept to a minimum and heavily specialized. Adds slightly more burn to account for it's removal. 